### PR TITLE
Add data provider component

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,6 +6,7 @@
       <router-link to="/table" tag="li" exact><a>Table</a></router-link>
       <router-link to="/popover" tag="li" exact><a>Popover</a></router-link>
       <router-link to="/switch" tag="li" exact><a>Switch</a></router-link>
+      <router-link to="/fetch" tag="li" exact><a>Fetch</a></router-link>
     </AdminMenu>
 
     <div id="wpcontent">

--- a/src/components/http/Fetch.vue
+++ b/src/components/http/Fetch.vue
@@ -1,0 +1,26 @@
+<script>
+    export default {
+        name: "Fetch",
+        props: ['url'],
+        data() {
+            return {
+                json: null,
+                loading: true
+            }
+        },
+        created() {
+            fetch(this.url)
+                .then(response => response.json())
+                .then(json => {
+                    this.json = json
+                    this.loading = false
+                })
+        },
+        render() {
+            return this.$scopedSlots.default({
+                json: this.json,
+                loading: this.loading
+            })
+        }
+    };
+</script>

--- a/src/router.js
+++ b/src/router.js
@@ -5,6 +5,7 @@ import Buttons from './views/Buttons.vue'
 import Table from './views/Table.vue'
 import Popover from './views/Popover.vue'
 import Switch from './views/Switch.vue'
+import Fetch from './views/Fetch.vue'
 
 Vue.use(Router)
 
@@ -18,5 +19,6 @@ export default new Router({
     { path: '/table', name: 'table', component: Table },
     { path: '/popover', name: 'popover', component: Popover },
     { path: '/switch', name: 'switch', component: Switch },
+    { path: '/fetch', name: 'fetch', component: Fetch },
   ]
 })

--- a/src/views/Fetch.vue
+++ b/src/views/Fetch.vue
@@ -1,0 +1,25 @@
+<template>
+	<section>
+		<h1>Fetch</h1>
+		<p>This renderless component acts as a <em>data provider</em> and exposes the <strong>fetched json</strong> to it's nested elements.</p>
+		<h4>Example:</h4>
+		<p>URL: https://jsonplaceholder.typicode.com/todos/:id</p>
+		<p>Fetched JSON:</p>
+		<fetch :url="`https://jsonplaceholder.typicode.com/todos/${Math.ceil(Math.random() * 10)}`">
+			<div slot-scope="{json: todo, loading}">
+				<p v-if="loading">Loading...</p>
+				<pre v-else>{{ todo }}</pre>
+			</div>
+		</fetch>
+	</section>
+</template>
+<script>
+	import Fetch from '@/components/http/Fetch'
+
+	export default {
+		name: 'FetchPage',
+		components: {
+			Fetch
+		}
+	}
+</script>


### PR DESCRIPTION
This PR adds a renderless component that acts as a _data provider_ and exposes the **fetched json** to it's nested elements.

This is useful when a component has to make a lot of HTTP `get` requests, which clutters up the `methods` property of a Vue instance with method definitions such as `fetchThis()` and `fetchThat()`.

With this component, all one has to do is provide the url.

**Example:**

```
<fetch url="https://jsonplaceholder.typicode.com/todos/1">
    <div slot-scope="{json: todo, loading}">
        <p v-if="loading">Loading...</p>
	<pre v-else>{{ todo }}</pre>
    </div>
</fetch>
```

In addition to fetched json, the component also provides a `loading` slot prop which allows maintaining the loading state for time-consuming HTTP calls.

Also, the current implementation uses the [deprecated](https://vuejs.org/v2/guide/components-slots.html#Deprecated-Syntax) `slot-scope` attribute, which requires an extra div. If we plan to update our Vue version to the latest one, the current implementation can be simplified using the new [v-slot](https://vuejs.org/v2/guide/components-slots.html#Scoped-Slots) directive.